### PR TITLE
Excluded FindBugs annotation packages from manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,9 @@
             <Export-Package>
               com.helger.commons.*
             </Export-Package>
+            <Import-Package>
+              !javax.annotation.*,*
+            </Import-Package>
           </instructions>
         </configuration>
       </plugin>


### PR DESCRIPTION
The `Export-Package` and `Import-Package` OSGi headers generated by the maven-bundle-plugin include references to classes in the `javax.annotation.*` packages used for FindBugs analysis.

This change prevents references to those packages from being created in those headers as annotations for FindBugs should not be required at runtime.
