### PR TITLE
Missing SchemaLocation property is added to AbstractJAXBMarshaller

### DIFF
--- a/ph-jaxb/src/main/java/com/helger/jaxb/AbstractJAXBMarshaller.java
+++ b/ph-jaxb/src/main/java/com/helger/jaxb/AbstractJAXBMarshaller.java
@@ -84,6 +84,7 @@ public abstract class AbstractJAXBMarshaller <JAXBTYPE>
   private NamespaceContext m_aNSContext;
   private Charset m_aCharset;
   private String m_sIndentString;
+   private String m_sSchemaLocation;
   private boolean m_bUseContextCache = JAXBBuilderDefaultSettings.DEFAULT_USE_CONTEXT_CACHE;
   private ClassLoader m_aClassLoader;
 
@@ -317,6 +318,23 @@ public abstract class AbstractJAXBMarshaller <JAXBTYPE>
   }
 
   /**
+   * Set the schema location to be used for writing JAXB objects.
+   *
+   * @param sSchemaLocation
+   *        The indent string to be used. May be <code>null</code>.
+   * @return {@link EChange}
+   * @since 8.5.3
+   */
+  @Nonnull
+  public EChange setSchemaLocation (@Nullable final String sSchemaLocation)
+  {
+    if (EqualsHelper.equals (sSchemaLocation, m_sSchemaLocation))
+      return EChange.UNCHANGED;
+    m_sSchemaLocation = sSchemaLocation;
+    return EChange.CHANGED;
+  }
+  
+  /**
    * Change whether the context cache should be used or not. Since creating the
    * JAXB context is quite cost intensive it is recommended to leave it enabled.
    *
@@ -493,6 +511,8 @@ public abstract class AbstractJAXBMarshaller <JAXBTYPE>
     if (m_sIndentString != null)
       JAXBMarshallerHelper.setSunIndentString (aMarshaller, m_sIndentString);
 
+    if (m_sSchemaLocation != null)
+      JAXBMarshallerHelper.setSchemaLocation(aMarshaller, m_sSchemaLocation);
     // Set XSD (if any)
     final Schema aValidationSchema = createValidationSchema ();
     if (aValidationSchema != null)

--- a/ph-jaxb/src/main/java/com/helger/jaxb/builder/JAXBBuilderDefaultSettings.java
+++ b/ph-jaxb/src/main/java/com/helger/jaxb/builder/JAXBBuilderDefaultSettings.java
@@ -54,6 +54,8 @@ public final class JAXBBuilderDefaultSettings
   private static Charset s_aCharset;
   @GuardedBy ("s_aRWLock")
   private static String s_sIndentString;
+  @GuardedBy ("s_aRWLock")
+  private static String s_sSchemaLocation;
 
   private JAXBBuilderDefaultSettings ()
   {}
@@ -189,5 +191,25 @@ public final class JAXBBuilderDefaultSettings
   public static String getDefaultIndentString ()
   {
     return s_aRWLock.readLocked ( () -> s_sIndentString);
+  }
+  /**
+   * Set the schema location to be used for writing JAXB objects.
+   *
+   * @param sIndentString
+   *        The indent string to be used by default. May be <code>null</code>.
+   */
+  public static void setDefaultSchemaLocation (@Nullable final String sSchemaLocation)
+  {
+    s_aRWLock.writeLocked ( () -> s_sSchemaLocation = sSchemaLocation);
+  }
+
+  /**
+   * @return The JAXB schema location to be used for writing.
+   *         <code>null</code> by default. 
+   */
+  @Nullable
+  public static String getDefaultSchemaLocation ()
+  {
+    return s_aRWLock.readLocked ( () -> s_sSchemaLocation);
   }
 }

--- a/ph-jaxb/src/main/java/com/helger/jaxb/builder/JAXBWriterBuilder.java
+++ b/ph-jaxb/src/main/java/com/helger/jaxb/builder/JAXBWriterBuilder.java
@@ -59,6 +59,7 @@ public class JAXBWriterBuilder <JAXBTYPE, IMPLTYPE extends JAXBWriterBuilder <JA
   private boolean m_bFormattedOutput = JAXBBuilderDefaultSettings.isDefaultFormattedOutput ();
   private Charset m_aCharset = JAXBBuilderDefaultSettings.getDefaultCharset ();
   private String m_sIndentString = JAXBBuilderDefaultSettings.getDefaultIndentString ();
+  private String m_sSchemaLocation = JAXBBuilderDefaultSettings.getDefaultSchemaLocation ();
 
   public JAXBWriterBuilder (@Nonnull final IJAXBDocumentType aDocType)
   {
@@ -178,6 +179,26 @@ public class JAXBWriterBuilder <JAXBTYPE, IMPLTYPE extends JAXBWriterBuilder <JA
     return thisAsT ();
   }
 
+  @Nullable
+  public String getSchemaLocation ()
+  {
+    return m_sSchemaLocation;
+  }
+
+  /**
+   * Set the Schema Location to be used for writing JAXB objects.
+   *
+   * @param sSchemaLocation
+   *        The Schema Location to be used. May be <code>null</code>.
+   * @return this for chaining
+   */
+  @Nonnull
+  public IMPLTYPE setSchemaLocation (@Nullable final String sSchemaLocation)
+  {
+    m_sSchemaLocation = sSchemaLocation;
+    return thisAsT ();
+  }
+  
   @Override
   @Nonnull
   protected Marshaller createMarshaller () throws JAXBException
@@ -213,6 +234,9 @@ public class JAXBWriterBuilder <JAXBTYPE, IMPLTYPE extends JAXBWriterBuilder <JA
 
     if (m_sIndentString != null)
       JAXBMarshallerHelper.setSunIndentString (aMarshaller, m_sIndentString);
+
+    if (m_sSchemaLocation != null)
+      JAXBMarshallerHelper.setSchemaLocation(aMarshaller, m_sSchemaLocation);
 
     return aMarshaller;
   }


### PR DESCRIPTION
Hi Philip,

While working with JAXBMarshaller, I need to set Schema Location property. Although it is already
implemented in JAXBMarshallerHelper, there is no definition at AbstractJAXBMarshaller.
So, I added some stuff to get that property.

Thanks,
Ahmet

