### PR TITLE
add tests for classes in com.helger.commons.io.stream package.

### DIFF
--- a/ph-commons/src/main/java/com/helger/commons/io/stream/NonBlockingBufferedWriter.java
+++ b/ph-commons/src/main/java/com/helger/commons/io/stream/NonBlockingBufferedWriter.java
@@ -25,6 +25,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 
 import com.helger.commons.CGlobal;
 import com.helger.commons.ValueEnforcer;
+import com.helger.commons.annotation.ReturnsMutableCopy;
 import com.helger.commons.system.SystemProperties;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -222,6 +223,59 @@ public class NonBlockingBufferedWriter extends Writer
     }
   }
 
+  /**
+   * Remove all content of the buffer.
+   */
+  public void reset ()
+  {
+    m_nNextChar = 0;
+  }
+
+  @Nonnegative
+  public int getSize ()
+  {
+    return m_nNextChar;
+  }
+  
+  @Nonnegative
+  public int getBufferSize ()
+  {
+    return m_aBuf.length;
+  }
+  
+  public boolean isEmpty ()
+  {
+    return m_nNextChar == 0;
+  }
+  
+  /**
+   * Converts input data to a string.
+   *
+   * @return the string.
+   */
+  @Nonnull
+  @ReturnsMutableCopy
+  public String getAsString ()
+  {
+    return new String (m_aBuf, 0, m_nNextChar);
+  }
+
+  /**
+   * Converts input data to a string.
+   *
+   * @param nLength
+   *        The number of characters to convert. Must be &le; than
+   *        {@link #getSize()}.
+   * @return the string.
+   */
+  @Nonnull
+  public String getAsString (@Nonnegative final int nLength)
+  {
+    ValueEnforcer.isBetweenInclusive (nLength, "Length", 0, m_nNextChar);
+    return new String (m_aBuf, 0, nLength);
+  }
+
+  
   /**
    * Writes a line separator. The line separator string is defined by the system
    * property <tt>line.separator</tt>, and is not necessarily a single newline

--- a/ph-commons/src/test/java/com/helger/commons/io/stream/ByteBufferInputStreamTest.java
+++ b/ph-commons/src/test/java/com/helger/commons/io/stream/ByteBufferInputStreamTest.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (C) 2014-2020 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.commons.io.stream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.nio.ByteOrder;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.junit.Test;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+
+import java.nio.ByteBuffer;
+
+/**
+ * Test class for class {@link ByteBufferInputStream}.
+ *
+ * @author Philip Helger
+ */
+
+public class ByteBufferInputStreamTest {
+  @SuppressWarnings ("resource")
+  @Test
+  @SuppressFBWarnings (value = "OS_OPEN_STREAM")
+  public void testAll () throws IOException
+  {
+    //byte [] bytes = new byte [100];
+    final ByteBuffer buf = ByteBuffer.allocate(100);
+    //ThreadLocalRandom.current ().nextBytes (buf);
+    try
+    {
+      new ByteBufferInputStream (null);
+      fail ();
+    }
+    catch (final NullPointerException ex)
+    {}
+
+    final ByteBufferInputStream bbis = new ByteBufferInputStream (buf);
+    assertEquals (100, bbis.available ());
+    bbis.read ();
+    assertEquals (1, bbis.skip (1));
+    assertEquals (98, bbis.available ());
+    bbis.read (new byte [9]);
+    bbis.read (new byte [0]);
+    bbis.read (new byte [91]);
+    assertEquals (-1, bbis.read ());
+    assertEquals (0, bbis.skip (10));
+
+    try
+    {
+      bbis.read ((byte []) null);
+      bbis.close ();
+      fail ();
+    }
+    catch (final NullPointerException ex)
+    {}
+    try
+    {
+      bbis.read ((byte []) null, 0, 10);
+      bbis.close ();
+      fail ();
+    }
+    catch (final NullPointerException ex)
+    {}
+    final byte [] x = new byte [100];
+    try
+    {
+      bbis.read (x, -1, 1);
+      bbis.close ();
+      fail ();
+    }
+    catch (final IllegalArgumentException ex)
+    {}
+    try
+    {
+      bbis.read (x, 1, -1);
+      bbis.close ();
+      fail ();
+    }
+    catch (final IllegalArgumentException ex)
+    {}
+    try
+    {
+      assertEquals (0, bbis.read (x, 90, 20));
+      bbis.close ();
+      fail ();
+    }
+    catch (final IllegalArgumentException ex)
+    {}
+
+    assertTrue (bbis.markSupported ());
+    bbis.mark (0);
+    bbis.reset ();
+  }
+}

--- a/ph-commons/src/test/java/com/helger/commons/io/stream/ByteBuffersInputStreamTest.java
+++ b/ph-commons/src/test/java/com/helger/commons/io/stream/ByteBuffersInputStreamTest.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (C) 2014-2020 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.commons.io.stream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+
+import org.junit.Test;
+import java.nio.ByteBuffer;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+/**
+ * Test class for class {@link ByteBuffersInputStream}.
+ *
+ * @author Philip Helger
+ */
+
+public class ByteBuffersInputStreamTest {
+  @SuppressWarnings ("resource")
+  @Test
+  @SuppressFBWarnings (value = "OS_OPEN_STREAM")
+  public void testAll () throws IOException
+  {
+    final ByteBuffer buf = ByteBuffer.allocate(100);
+    try
+    {
+      new ByteBuffersInputStream (null);
+      fail ();
+    }
+    catch (final NullPointerException ex)
+    {}
+
+    final ByteBuffersInputStream bbis = new ByteBuffersInputStream (buf);
+    assertEquals (100, bbis.available ());
+    bbis.read ();
+    assertEquals (1, bbis.skip (1));
+    assertEquals (98, bbis.available ());
+    bbis.read (new byte [9]);
+    bbis.read (new byte [0]);
+    bbis.read (new byte [91]);
+    assertEquals (-1, bbis.read ());
+    assertEquals (0, bbis.skip (10));
+
+    try
+    {
+      bbis.read ((byte []) null);
+      bbis.close ();
+      fail ();
+    }
+    catch (final NullPointerException ex)
+    {}
+    try
+    {
+      bbis.read ((byte []) null, 0, 10);
+      bbis.close ();
+      fail ();
+    }
+    catch (final NullPointerException ex)
+    {}
+    final byte [] x = new byte [100];
+    try
+    {
+      bbis.read (x, -1, 1);
+      bbis.close ();
+      fail ();
+    }
+    catch (final IllegalArgumentException ex)
+    {}
+    try
+    {
+      bbis.read (x, 1, -1);
+      bbis.close ();
+      fail ();
+    }
+    catch (final IllegalArgumentException ex)
+    {}
+    try
+    {
+      assertEquals (0, bbis.read (x, 90, 20));
+      bbis.close ();
+      fail ();
+    }
+    catch (final IllegalArgumentException ex)
+    {}
+
+    assertTrue (bbis.markSupported ());
+    bbis.mark (0);
+    bbis.reset ();
+  }
+}

--- a/ph-commons/src/test/java/com/helger/commons/io/stream/NonBlockingBufferedWriterTest.java
+++ b/ph-commons/src/test/java/com/helger/commons/io/stream/NonBlockingBufferedWriterTest.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (C) 2014-2020 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.commons.io.stream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.Writer;
+
+import org.junit.Test;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+/**
+ * Test class for class {@link NonBlockingBufferedWriter}.
+ *
+ * @author Philip Helger
+ */
+
+public class NonBlockingBufferedWriterTest {
+  @Test
+  @SuppressFBWarnings ("TQ_NEVER_VALUE_USED_WHERE_ALWAYS_REQUIRED")
+  public void testAll () throws IOException
+  { 
+    final NonBlockingStringWriter aSW = new NonBlockingStringWriter ();
+    try (final NonBlockingBufferedWriter aBBW = new NonBlockingBufferedWriter (aSW))
+    {
+      assertTrue (aBBW.isEmpty ());
+      assertEquals (0, aBBW.getSize ());
+      aBBW.write ('a');
+      assertFalse (aBBW.isEmpty ());
+      assertEquals (1, aBBW.getSize ());
+      aBBW.write ("bc".toCharArray ());
+      aBBW.write ("de".toCharArray (), 0, 1);
+      aBBW.write ("ef");
+      aBBW.write ("fgh", 1, 1);
+      assertEquals ("abcdefg", aBBW.getAsString ());
+      assertEquals (7, aBBW.getSize ());
+      aBBW.append ('0').append ("12").append ("234", 1, 2);
+      assertEquals ("abcdefg0123", aBBW.getAsString ());
+      aBBW.append (null).append (null, 1, 2);
+      assertEquals ("abcdefg0123nullu", aBBW.getAsString ());
+      aBBW.flush ();
+    }
+  }
+
+  @Test
+  @SuppressWarnings ("resource")
+  @SuppressFBWarnings ("OS_OPEN_STREAM")
+  public void testError ()
+  {
+    try
+    {
+      final NonBlockingStringWriter aSW = new NonBlockingStringWriter (-1);
+      fail ();
+    }
+    catch (final IllegalArgumentException ex)
+    {}
+    try
+    {
+      new NonBlockingBufferedWriter (new NonBlockingStringWriter (-1));
+      fail ();
+    }
+    catch (final IllegalArgumentException ex)
+    {}
+
+    final char [] ca = "abc".toCharArray ();
+    try
+    {
+      new NonBlockingBufferedWriter (new NonBlockingStringWriter (-1)).write (ca, -1, 1);
+      fail ();
+    }
+    catch (final IllegalArgumentException ex)
+    {}
+    catch (final IOException iox)
+    {}
+    try
+    {
+      new NonBlockingBufferedWriter (new NonBlockingStringWriter (-1)).write (ca, 0, -1);
+      fail ();
+    }
+    catch (final IllegalArgumentException ex)
+    {}
+    catch (final IOException iox)
+    {}
+    try
+    {
+      new NonBlockingBufferedWriter (new NonBlockingStringWriter (-1)).write (ca, 2, 5);
+      fail ();
+    }
+    catch (final IllegalArgumentException ex)
+    {}
+    catch (final IOException iox)
+    {}
+  }
+}

--- a/ph-commons/src/test/java/com/helger/commons/io/stream/NonBlockingCharArrayWriterTest.java
+++ b/ph-commons/src/test/java/com/helger/commons/io/stream/NonBlockingCharArrayWriterTest.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (C) 2014-2020 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.commons.io.stream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.Writer;
+
+import org.junit.Test;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+/**
+ * Test class for class {@link NonBlockingCharArrayWriter}.
+ *
+ * @author Philip Helger
+ */
+
+public class NonBlockingCharArrayWriterTest {
+  @Test
+  @SuppressFBWarnings ("TQ_NEVER_VALUE_USED_WHERE_ALWAYS_REQUIRED")
+  public void testAll () throws IOException
+  { 
+    try (final NonBlockingCharArrayWriter aCAW = new NonBlockingCharArrayWriter ())
+    {
+      assertTrue (aCAW.isEmpty ());
+      assertEquals (0, aCAW.getSize ());
+      aCAW.write ('a');
+      assertFalse (aCAW.isEmpty ());
+      assertEquals (1, aCAW.getSize ());
+      aCAW.write ("bc".toCharArray ());
+      aCAW.write ("de".toCharArray (), 0, 1);
+      aCAW.write ("ef");
+      aCAW.write ("fgh", 1, 1);
+      assertEquals ("abcdefg", aCAW.getAsString ());
+      assertEquals (7, aCAW.getSize ());
+      aCAW.append ('0').append ("12").append ("234", 1, 2);
+      assertEquals ("abcdefg0123", aCAW.getAsString ());
+      aCAW.append (null).append (null, 1, 2);
+      assertEquals ("abcdefg0123nullu", aCAW.getAsString ());
+      aCAW.flush ();
+    }
+  }
+
+  @Test
+  @SuppressWarnings ("resource")
+  @SuppressFBWarnings ("OS_OPEN_STREAM")
+  public void testError ()
+  {
+    try
+    {
+      new NonBlockingCharArrayWriter (-1);
+      fail ();
+    }
+    catch (final IllegalArgumentException ex)
+    {}
+
+    final char [] ca = "abc".toCharArray ();
+    try
+    {
+      new NonBlockingCharArrayWriter ().write (ca, -1, 1);
+      fail ();
+    }
+    catch (final IllegalArgumentException ex)
+    {}
+    try
+    {
+      new NonBlockingCharArrayWriter ().write (ca, 0, -1);
+      fail ();
+    }
+    catch (final IllegalArgumentException ex)
+    {}
+    try
+    {
+      new NonBlockingCharArrayWriter ().write (ca, 2, 5);
+      fail ();
+    }
+    catch (final IllegalArgumentException ex)
+    {}
+  }
+}


### PR DESCRIPTION
Patrick Lam and I are doing some research on automatically proposing
useful test cases for software systems. The idea is to add test cases
for sibling classes in cases where some, but not all, of the siblings
are tested. We believe there should be easy wins from proposing
tests for uncovered methods in sibling classes C' of tested classes C.

This first commit targets easy examples where the system under test's
methods are directly called from unit tests in a corresponding test class. 
It mirrors existing tests for NonBlockingStringWriter and NonBlockingByteArrayInputStream,
and applies to their sibling classes.

We hope that you find these tests useful and would appreciate merging or
comments with your thoughts on such tests.