### PR TITLE
Update Bouncy Castle to 1.78

### DIFF
--- a/ph-bc/src/main/java/com/helger/bc/config/ThirdPartyModuleProvider_ph_bc.java
+++ b/ph-bc/src/main/java/com/helger/bc/config/ThirdPartyModuleProvider_ph_bc.java
@@ -38,7 +38,7 @@ public final class ThirdPartyModuleProvider_ph_bc implements IThirdPartyModulePr
   public static final IThirdPartyModule BOUNCY_CASTLE = new ThirdPartyModule ("Bouncy Castle",
                                                                               "Legion of the Bouncy Castle",
                                                                               ELicense.MIT,
-                                                                              new Version (1, 77),
+                                                                              new Version (1, 78),
                                                                               "https://www.bouncycastle.org/");
 
   @Nonnull

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
   <properties>
     <!-- For surefire plugin (use property for JaCoCo integration) -->
     <argLine>-Xmx1024m</argLine>
-    <bc.version>1.77</bc.version>
+    <bc.version>1.78</bc.version>
     <bcpg.version>${bc.version}</bcpg.version>
   </properties>
   


### PR DESCRIPTION
Update Bouncy Castle to 1.78 (because of some CVEs -> https://www.bouncycastle.org/releasenotes.html#r1rv78)